### PR TITLE
Bytt til GITHUB_TOKEN

### DIFF
--- a/.github/workflows/build-deploy.yaml
+++ b/.github/workflows/build-deploy.yaml
@@ -46,11 +46,11 @@ jobs:
             ${{ runner.os }}-buildx-
 
       - name: Login to ghcr.io
-        uses: docker/login-action@v1 
+        uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_PUSH_USERNAME }}
-          password: ${{ secrets.GHCR_PUSH_TOKEN }}
+          username: ${{ github.repository }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         id: docker_build
@@ -60,7 +60,7 @@ jobs:
           file: ./Dockerfile
           builder: ${{ steps.buildx.outputs.name }}
           push: true
-          tags: ${{ env.APP_IMAGE }} 
+          tags: ${{ env.APP_IMAGE }}
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache
 


### PR DESCRIPTION
Vi ønsker at så mange som mulig bruker GITHUB_TOKEN der det er mulig. Tidligere fungerte det ikke så bra med GHCR, men dette skal ha blitt fikset nå, derfor denne pull requesten.
